### PR TITLE
Added lastvisited pagemethod to allow its use in a stats section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,19 @@ The tracking image will be moved below the fold and trigger the counter [with na
 
 ## SQLite database (default)
 
-To view the tracked count and timestamp this plugin provides two optional fields.
+To view the tracked count and timestamp this plugin provides two optional fields, and  two pagemethods.
 
 **in your page blueprint**
 ```yml
+ stats:
+     type: stats
+     reports:
+         - label: View Count of Page
+           value: "{{ page.pageviewcount }}"
+         - label: View Count with Children
+           value: "{{ page.children.pageviewcount(page.pageviewcount) }}"
+         - label: Last Visited
+           value: "{{ page.lastvisited(Y-m-d H:i:s) }}" # for format options see https://www.php.net/manual/en/function.date.php
 fields:
   counter:
     label: Page view count

--- a/index.php
+++ b/index.php
@@ -75,6 +75,9 @@ Kirby::plugin('bnomei/pageviewcounter', [
         'pageviewcount' => function (): int {
             return \Bnomei\PageViewCounter::singleton()->count($this->id()); // id NOT uuid!
         },
+        'lastvisited' => function ($format = 'c'): string { //for format options see https://www.php.net/manual/en/function.date.php
+            return date($format, \Bnomei\PageViewCounter::singleton()->timestamp($this->id())); // id NOT uuid!
+        },
         'counterImage' => function () {
             $url = $this->url(
                 kirby()->languages()->count() > 1 ?


### PR DESCRIPTION
Lastvisited can now be accessed with a pagemethod. Felt like that was nice to use in a stats section or something else. 
I don't know whether this way of passing a format option is the best way, but it works (I couldn't get the kirby datehandler to work, so it's the default PHP date format that needs to be used)

Also updated the readme to reflect the new pagemethods in a stats section.